### PR TITLE
Make user credentials persist on refresh

### DIFF
--- a/src/hooks/auth.tsx
+++ b/src/hooks/auth.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useState } from "react"
+import React, { createContext, ReactNode, useContext, useEffect, useState } from "react"
 
 export interface AuthContext {
   setUser: (username: string | null) => void
@@ -8,7 +8,13 @@ export interface AuthContext {
 const AuthContext = createContext<AuthContext | null>(null)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<string | null>(null)
+  const [user, setUser] = useState<string | null>(sessionStorage.getItem('user'))
+
+  useEffect(() => {
+    if (user) sessionStorage.setItem('user', user)
+    else sessionStorage.removeItem('user')
+  }, [user])
+
   return (
     <AuthContext.Provider value={{ user, setUser }}>
       {children}


### PR DESCRIPTION
Save user into `sessionStorage`, so now refreshing the page will not cause user to lose the login session.